### PR TITLE
fix typo at FSharpApiSearch/README.md

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -22,7 +22,7 @@ group Build
 group Doc
   source https://api.nuget.org/v3/index.json
 
-  github hafuu/FSharpApiSearch:d5946fa3540c14793129508271b42d7366f674cb README.md
+  github hafuu/FSharpApiSearch:450fe8cd579fdd26916ee7a5bb68d6d8741b3280 README.md
 
 group Database
   source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -64,7 +64,7 @@ NUGET
 GITHUB
   remote: hafuu/FSharpApiSearch
   specs:
-    README.md (d5946fa3540c14793129508271b42d7366f674cb)
+    README.md (450fe8cd579fdd26916ee7a5bb68d6d8741b3280)
       FParsec
       FSharp.Compiler.Service
       FsPickler


### PR DESCRIPTION
アクティブパターンの例が間違ってました。
